### PR TITLE
Fix access to quota values

### DIFF
--- a/TileLayer.Grayscale.js
+++ b/TileLayer.Grayscale.js
@@ -8,7 +8,9 @@ L.TileLayer.Grayscale = L.TileLayer.extend({
 		quotaRed: 3,
 		quotaGreen: 4,
 		quotaBlue: 1,
-		quotaDivider: quotaRed + quotaGreen + quotaBlue,
+		quotaDivider: function() {
+			return this.quotaRed + this.quotaGreen + this.quotaBlue + this.quotaDividerTune;
+		}
 	},
 
 	initialize: function (url, options) {
@@ -39,7 +41,7 @@ L.TileLayer.Grayscale = L.TileLayer.extend({
 			var imgd = ctx.getImageData(0, 0, this._layer.options.tileSize, this._layer.options.tileSize);
 			var pix = imgd.data;
 			for (var i = 0, n = pix.length; i < n; i += 4) {
-				pix[i] = pix[i + 1] = pix[i + 2] = (quotaRed * pix[i] + quotaGreen * pix[i + 1] + quotaBlue * pix[i + 2]) / quotaDivider;
+				pix[i] = pix[i + 1] = pix[i + 2] = (this._layer.options.quotaRed * pix[i] + this._layer.options.quotaGreen * pix[i + 1] + this._layer.options.quotaBlue * pix[i + 2]) / this._layer.options.quotaDivider();
 			}
 			ctx.putImageData(imgd, 0, 0);
 			this.removeAttribute("crossorigin");

--- a/TileLayer.Grayscale.js
+++ b/TileLayer.Grayscale.js
@@ -8,6 +8,7 @@ L.TileLayer.Grayscale = L.TileLayer.extend({
 		quotaRed: 3,
 		quotaGreen: 4,
 		quotaBlue: 1,
+		quotaDividerTune: 0,
 		quotaDivider: function() {
 			return this.quotaRed + this.quotaGreen + this.quotaBlue + this.quotaDividerTune;
 		}


### PR DESCRIPTION
Moving `quotaRed`, `quotaGreen`, `quotaBlue`, and `quotaDivider` values into the `options` object was resulting in breaking errors for me. Those values could not be accessed as written. I think because they were being treated as variable rather than values in an object. This pull request seeks to:

- Continue exposing the quota values as options
- Make it so the the quota values are accessed as values in an object rather than variables.
- Add an option, `quotaDividerTune` that allows one to adjust `quotaDivider` and thus the darkness or brightness of the grayscale output