### PR TITLE
protect against options parameter not being supplied, as in L.tileLay…

### DIFF
--- a/TileLayer.Grayscale.js
+++ b/TileLayer.Grayscale.js
@@ -14,6 +14,7 @@ L.TileLayer.Grayscale = L.TileLayer.extend({
 	},
 
 	initialize: function (url, options) {
+		options = options || {}
 		options.crossOrigin = true;
 		L.TileLayer.prototype.initialize.call(this, url, options);
 


### PR DESCRIPTION
…er.grayscale(url);

Hi Ilya, 

Great plugin!

I made a slight change, so I could mimic:

`let lyrOSM = L.tileLayer( 'http://{s}.tile.osm.org/{z}/{x}/{y}.png' );`

as

`let lyrOSM = L.tileLayer.grayscale( 'http://{s}.tile.osm.org/{z}/{x}/{y}.png' );`

If I don't supply an options param, the `options.crossOrigin = true;` call breaks.

My JavaScript is not exactly strong, so there is probably a better syntax for what I did.

Or, even, you just may not be interested in my change, which is also fine :)

Take care!

steve